### PR TITLE
Non-breaking fixes for image-minify refactor

### DIFF
--- a/packages/image-minify/index.js
+++ b/packages/image-minify/index.js
@@ -7,9 +7,9 @@ module.exports = (neutrino, opts = {}) => {
   const options = merge({
     imagemin: {
       plugins: [],
-      optipng: {},
-      gifsicle: {},
-      jpegtran: {},
+      optipng: null,
+      gifsicle: null,
+      jpegtran: null,
       svgo: {},
       pngquant: {},
       webp: {}

--- a/packages/image-minify/index.js
+++ b/packages/image-minify/index.js
@@ -8,7 +8,7 @@ module.exports = (neutrino, opts = {}) => {
     imagemin: {
       plugins: [],
       optipng: null,
-      gifsicle: null,
+      gifsicle: {},
       jpegtran: null,
       svgo: {},
       pngquant: {},

--- a/packages/image-minify/index.js
+++ b/packages/image-minify/index.js
@@ -1,6 +1,7 @@
 const merge = require('deepmerge');
 const ImageminWebpackPlugin = require('imagemin-webpack-plugin').default;
 const webp = require('imagemin-webp');
+const mozjpeg = require('imagemin-mozjpeg');
 
 module.exports = (neutrino, opts = {}) => {
   const options = merge({
@@ -10,7 +11,7 @@ module.exports = (neutrino, opts = {}) => {
       gifsicle: {},
       jpegtran: {},
       svgo: {},
-      pngquant: null,
+      pngquant: {},
       webp: {}
     },
     pluginId: 'imagemin'
@@ -18,6 +19,10 @@ module.exports = (neutrino, opts = {}) => {
 
   if (options.webp) {
     options.imagemin.plugins.push(webp(options.webp));
+  }
+
+  if (options.mozjpeg) {
+    options.imagemin.plugins.push(mozjpeg(options.mozjpeg));
   }
 
   neutrino.config

--- a/packages/image-minify/package.json
+++ b/packages/image-minify/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "deepmerge": "^1.5.2",
+    "imagemin-mozjpeg": "^7.0.0",
     "imagemin-webp": "^4.1.0",
     "imagemin-webpack-plugin": "^1.6.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5675,6 +5675,14 @@ imagemin-jpegtran@^5.0.2:
     is-jpg "^1.0.0"
     jpegtran-bin "^3.0.0"
 
+imagemin-mozjpeg@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/imagemin-mozjpeg/-/imagemin-mozjpeg-7.0.0.tgz#d926477fc6ef5f3a768a4222f7b2d808d3eba568"
+  dependencies:
+    execa "^0.8.0"
+    is-jpg "^1.0.0"
+    mozjpeg "^5.0.0"
+
 imagemin-optipng@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/imagemin-optipng/-/imagemin-optipng-5.2.1.tgz#d22da412c09f5ff00a4339960b98a88b1dbe8695"
@@ -7810,6 +7818,14 @@ move-concurrently@^1.0.1, move-concurrently@~1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
+
+mozjpeg@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/mozjpeg/-/mozjpeg-5.0.0.tgz#b8671c4924568a363de003ff2fd397ab83f752c5"
+  dependencies:
+    bin-build "^2.2.0"
+    bin-wrapper "^3.0.0"
+    logalot "^2.0.0"
 
 ms@0.7.1:
   version "0.7.1"


### PR DESCRIPTION
See #673

This enables mozjpeg and pngquant, as they were enabled with the v8 release.

It also disables optipng and jpegtran for the same reason.
I think those are both lossless, so you might not consider enabling them a breaking change.
